### PR TITLE
refactor: url path for transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ sequenceDiagram
 
     %% ISO20022 Message Pain001
     rect rgb(105, 105, 105)
-        Client ->>+ TMS: POST /v1/Pain001.001.11: Pain001.001.11 Message
+        Client ->>+ TMS: POST /v1/evaluate/iso20022/pain.001.001.11: Pain001.001.11 Message
         TMS ->> TMS: Validate Pain001
         TMS ->> log: Logging of receipt
         alt Validation Error
         TMS ->> log: Logging of error
-        TMS ->> Client: /v1/Pain001.001.11 POST Result
+        TMS ->> Client: /v1/evaluate/iso20022/pain.001.001.11 POST Result
         end
 
         rect rgb(173, 216, 230)
@@ -52,17 +52,17 @@ sequenceDiagram
         TMS ->> TMS: Throw error
         end
         TMS ->> log: Transaction sent to ED service
-        TMS ->> Client: /v1/Pain001.001.11 POST Result
+        TMS ->> Client: /v1/evaluate/iso20022/pain.001.001.11 POST Result
     end
 
     %% ISO20022 Message Pain013
     rect rgb(105, 105, 105)
-        Client ->>+ TMS: POST /v1/Pain013.001.09: Pain013.001.09 Message
+        Client ->>+ TMS: POST /v1/evaluate/iso20022/pain.013.001.09: Pain013.001.09 Message
         TMS ->> TMS: Validate Pain013
         TMS ->> log: Logging of receipt
         alt Validation Error
         TMS ->> log: Logging of error
-        TMS ->> Client: /v1/Pain013.001.09 POST Result
+        TMS ->> Client: /v1/evaluate/iso20022/pain.013.001.09 POST Result
         end
 
         rect rgb(173, 216, 230)
@@ -87,17 +87,17 @@ sequenceDiagram
         TMS ->> TMS: Throw error
         end
         TMS ->> log: Transaction sent to ED service
-        TMS ->> Client: /v1/Pain013.001.09 POST Result
+        TMS ->> Client: /v1/evaluate/iso20022/pain.013.001.09 POST Result
     end
 
     %% ISO20022 Message Pacs008
     rect rgb(105, 105, 105)
-        Client ->>+ TMS: POST /v1/Pacs008.001.10: Pacs008.001.10 Message
+        Client ->>+ TMS: POST /v1/evaluate/iso20022/pacs.008.001.10: Pacs008.001.10 Message
         TMS ->> TMS: Validate Pacs008
         TMS ->> log: Logging of receipt
         alt Validation Error
         TMS ->> log: Logging of error
-        TMS ->> Client: /v1/Pacs008.001.10 POST Result
+        TMS ->> Client: /v1/evaluate/iso20022/pacs.008.001.10 POST Result
         end
 
         rect rgb(173, 216, 230)
@@ -122,7 +122,7 @@ sequenceDiagram
         TMS ->> TMS: Throw error
         end
         TMS ->> log: Transaction sent to ED service
-        TMS ->> Client: /v1/Pacs008.001.10 POST Result
+        TMS ->> Client: /v1/evaluate/iso20022/pacs.008.001.10 POST Result
     end
 ```
 
@@ -194,7 +194,6 @@ graph TD
   
   ```json
   {
-  "TxTp": "pain.001.001.11",
   "CstmrCdtTrfInitn": {
     "GrpHdr": {
       "MsgId": "24988b914e3d4cf98a7659b2c45ce063258",
@@ -406,7 +405,6 @@ graph TD
 
 ```json
 {
-  "TxTp": "pain.013.001.09",
   "CdtrPmtActvtnReq": {
     "GrpHdr": {
       "MsgId": "42665509efd844da90caf468e891aa52256",
@@ -615,7 +613,6 @@ graph TD
 
 ```json
 {
-  "TxTp": "pacs.008.001.10",
   "FIToFICstmrCdt": {
     "GrpHdr": {
       "MsgId": "24e80c9836f6437e8aa46cbb3fbdd5b1",
@@ -797,7 +794,6 @@ graph TD
   
   ```json
 {
-  "TxTp": "pacs.002.001.12",
   "FIToFIPmtSts": {
     "GrpHdr": {
       "MsgId": "e24562287a264651b0c42a3de9ea44fe",

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,11 +9,11 @@ async function Routes(fastify: FastifyInstance, options: unknown): Promise<void>
   fastify.get('/', handleHealthCheck);
   fastify.get('/health', handleHealthCheck);
   if (configuration.quoting) {
-    fastify.post('/v1/pain.001.001.11', SetOptions(Pain001Handler, 'messageSchemaPain001'));
-    fastify.post('/v1/pain.013.001.09', SetOptions(Pain013Handler, 'messageSchemaPain013'));
+    fastify.post('/v1/evaluate/iso20022/pain.001.001.11', SetOptions(Pain001Handler, 'messageSchemaPain001'));
+    fastify.post('/v1/evaluate/iso20022/pain.013.001.09', SetOptions(Pain013Handler, 'messageSchemaPain013'));
   }
-  fastify.post('/v1/pacs.008.001.10', SetOptions(Pacs008Handler, 'messageSchemaPacs008'));
-  fastify.post('/v1/pacs.002.001.12', SetOptions(Pacs002Handler, 'messageSchemaPacs002'));
+  fastify.post('/v1/evaluate/iso20022/pacs.008.001.10', SetOptions(Pacs008Handler, 'messageSchemaPacs008'));
+  fastify.post('/v1/evaluate/iso20022/pacs.002.001.12', SetOptions(Pacs002Handler, 'messageSchemaPacs002'));
 }
 
 export default Routes;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -38,7 +38,7 @@ paths:
             $ref: '#/definitions/Health'
         500:
           $ref: '#/responses/500'
-  /v1/pain.001.001.11:
+  /v1/evaluate/iso20022/pain.001.001.11:
     post:
       summary: 'pain.001.001.11 Transaction'
       description: 'ISO20022 pain.001.001.11 formatted message expected. Historically Mojaloop Quote message.'
@@ -64,7 +64,7 @@ paths:
           $ref: '#/responses/401'
         500:
           $ref: '#/responses/500'
-  /v1/pain.013.001.09:
+  /v1/evaluate/iso20022/pain.013.001.09:
     post:
       summary: 'pain.013.001.09 Transaction'
       description: 'ISO20022 pain.013.001.09 formatted message expected. Historically Mojaloop Quote Response message.'
@@ -90,7 +90,7 @@ paths:
           $ref: '#/responses/401'
         500:
           $ref: '#/responses/500'
-  /v1/pacs.008.001.10:
+  /v1/evaluate/iso20022/pacs.008.001.10:
     post:
       summary: 'pacs.008.001.10'
       description: 'ISO20022 pacs.008.001.10 formatted message expected. Historically Mojaloop Transfer message.'
@@ -116,7 +116,7 @@ paths:
           $ref: '#/responses/401'
         500:
           $ref: '#/responses/500'
-  /v1/pacs.002.001.12:
+  /v1/evaluate/iso20022/pacs.002.001.12:
     post:
       summary: 'pacs.002.001.12'
       description: 'ISO20022 pacs.002.001.12 formatted message expected.'


### PR DESCRIPTION
This PR further adds more branches on the path of the routes of the transaction submission endpoints
Related to https://github.com/frmscoe/tms-service/pull/174

- [x] Huskey: pre-commit -> npx lint-staged, pre-push -> npm test

![image](https://github.com/frmscoe/tms-service/assets/131665740/11f21aab-aead-46ce-85f1-4819c022ddb7)
 