### PR TITLE
fix: validation validator compiler

### DIFF
--- a/src/schemas/pacs.002.json
+++ b/src/schemas/pacs.002.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "FIToFIPmtSts": {

--- a/src/schemas/pacs.008.json
+++ b/src/schemas/pacs.008.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "FIToFICstmrCdt": {

--- a/src/schemas/pain.001.json
+++ b/src/schemas/pain.001.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "CstmrCdtTrfInitn": {

--- a/src/schemas/pain.013.json
+++ b/src/schemas/pain.013.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "CdtrPmtActvtnReq": {


### PR DESCRIPTION
BUG FIX PR

Trait: No accurate validation error message from response object 

Fix:  Add schemas through ajv to validate them using your custom ajv schema validator

Cause: Bumping of ajv and fastify

Proof of outcome:
![image](https://github.com/frmscoe/tms-service/assets/131665740/3850fb20-4884-4979-9625-74e138fb44b7)
