### PR TITLE
Add workflow action for SBOM geenration using syft scan

### DIFF
--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -16,6 +16,7 @@
 name: Anchore Syft SBOM scan
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "dev", "main" ]
 

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow checks out code, builds an image, performs a container image
+# scan with Anchore's Syft tool, and uploads the results to the GitHub Dependency
+# submission API.
+
+# For more information on the Anchore sbom-action usage
+# and parameters, see https://github.com/anchore/sbom-action. For more
+# information about the Anchore SBOM tool, Syft, see
+# https://github.com/anchore/syft
+name: Anchore Syft SBOM scan
+
+on:
+  push:
+    branches: [ "dev", "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  Anchore-Build-Scan:
+    permissions:
+      contents: write # required to upload to the Dependency submission API
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag localbuild/testimage:latest
+    - name: Scan the image and upload dependency results
+      uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
+      with:
+        image: "localbuild/testimage:latest"
+        artifact-name: image.spdx.json
+        dependency-snapshot: true


### PR DESCRIPTION
By default, this action will execute a Syft scan in the workspace directory and upload a workflow artifact SBOM in SPDX format. It will also detect if being run during a [GitHub release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) and upload the SBOM as a release asset.