### PR TITLE
fix: `InitPty` missing in Pacs008 schema

### DIFF
--- a/src/schemas/pacs.008.json
+++ b/src/schemas/pacs.008.json
@@ -505,11 +505,29 @@
                 "Doc": {
                   "type": "object",
                   "properties": {
+                    "InitgPty": {
+                      "type": "object",
+                      "properties": {
+                        "Glctn": {
+                          "type": "object",
+                          "properties": {
+                            "Lat": {
+                              "type": "string"
+                            },
+                            "Long": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["Lat", "Long"]
+                        }
+                      },
+                      "required": ["Glctn"]
+                    },
                     "Xprtn": {
                       "type": "string"
                     }
                   },
-                  "required": ["Xprtn"]
+                  "required": ["InitgPty", "Xprtn"]
                 }
               },
               "required": ["Doc"]


### PR DESCRIPTION
## What did we change?
`InitPty` is now required in the Pacs008 schema

## Why are we doing this?
When the pain.001 and 013 messages were allowed to be optional, we needed to move some of the data from the pain.001 message to the pacs.008 messages for the rules (e.g. Geolocation rules) that relied on this information to be able to retrieve it from the pacs.008 messages since the pain.001 message was no longer going to be provided.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
