### PR TITLE
feat: Datacache lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fastify/response-validation": "^2.6.0",
         "@fastify/swagger": "^8.8.0",
         "@fastify/swagger-ui": "^3.0.0",
-        "@frmscoe/frms-coe-lib": "^4.0.0-rc.10",
+        "@frmscoe/frms-coe-lib": "^4.0.0-rc.11",
         "@frmscoe/frms-coe-startup-lib": "2.2.0-rc.3",
         "ajv": "^8.16.0",
         "arangojs": "^8.8.0",
@@ -987,9 +987,9 @@
       }
     },
     "node_modules/@frmscoe/frms-coe-lib": {
-      "version": "4.0.0-rc.10",
-      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-lib/4.0.0-rc.10/243fd9e34c910718b533ffc93857034f7bf18f48",
-      "integrity": "sha512-8UOOhyqoOWnA500uImBHK5zMlj+ro9RtJtCgSNsAOT6BPHhTguPRU8jaImxRtHM5FsblNBfxsTrx6J5FUm1q1A==",
+      "version": "4.0.0-rc.11",
+      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-lib/4.0.0-rc.11/9276c592b4d47a9352487b35f27da014cc4a64e4",
+      "integrity": "sha512-UrIG/ftrlTQ/ezro0mSuKbCAjld0zC6FsoyWgdf0Au8UMtEPfU36cT7kQ6idWG07PVvRlamU/kD7ZKGXVNm0jw==",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
         "@grpc/grpc-js": "^1.10.9",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@fastify/response-validation": "^2.6.0",
     "@fastify/swagger": "^8.8.0",
     "@fastify/swagger-ui": "^3.0.0",
-    "@frmscoe/frms-coe-lib": "^4.0.0-rc.10",
+    "@frmscoe/frms-coe-lib": "^4.0.0-rc.11",
     "@frmscoe/frms-coe-startup-lib": "2.2.0-rc.3",
     "ajv": "^8.16.0",
     "arangojs": "^8.8.0",

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -64,6 +64,9 @@ export const handlePain001 = async (transaction: Pain001, transactionType: strin
     cdtrAcctId: creditorAcctId,
     dbtrAcctId: debtorAcctId,
   };
+
+  transaction.DataCache = dataCache;
+
   const spanInsert = apm.startSpan('db.insert.pain001');
   try {
     await Promise.all([
@@ -159,6 +162,7 @@ export const handlePain013 = async (transaction: Pain013, transactionType: strin
     dbtrId,
   };
 
+  transaction.DataCache = dataCache;
   transaction._key = MsgId;
 
   const spanInsert = apm.startSpan('db.insert.pain013');
@@ -256,6 +260,8 @@ export const handlePacs008 = async (transaction: Pacs008, transactionType: strin
       ccy: Ccy,
     },
   };
+  transaction.DataCache = dataCache;
+
   const cacheBuffer = createMessageBuffer({ DataCache: { ...dataCache } });
   if (cacheBuffer) {
     accountInserts.push(cacheDatabaseManager.set(EndToEndId, cacheBuffer, configuration.cacheTTL));
@@ -354,6 +360,7 @@ export const handlePacs002 = async (transaction: Pacs002, transactionType: strin
   }
 
   transaction._key = MsgId;
+  transaction.DataCache = dataCache;
 
   const spanInsert = apm.startSpan('db.insert.pacs002');
   try {


### PR DESCRIPTION
In Relation: https://github.com/frmscoe/tms-service/issues/203

## What did we change?

We included the saving of the data cache in the transactional history entry

## Why are we doing this?

So the rules can use the composite keys. 

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
