### PR TITLE
fix: use passing node.js workflow without integration tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
@@ -43,217 +45,32 @@ env:
   THRESHOLD: 5
   REPO_NAME: 'performance-benchmark'
   ITERATION_COUNT: 500
+
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "dev", "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "dev", "main" ]
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      responseAverage: ${{ steps.newman_test.outputs.responseAverage }}
-      responseMin: ${{ steps.newman_test.outputs.responseMin }}
-      responseMax: ${{ steps.newman_test.outputs.responseMax }}
-      responseSd: ${{ steps.newman_test.outputs.responseSd }}
-      numberOfTest: ${{ steps.newman_test.outputs.numberOfTest }}
-      resultOutput: ${{ steps.output_test.outputs.resultOutput}}
-    name: integration test
-    permissions:
-      packages: write
-      contents: read
+    name: run build
     strategy:
       matrix:
-        node-version: [20]
-        redis-version: [6]
+        node-version: [16, 20]
     steps:
       - uses: actions/checkout@v4
-      - name: Start Arango
-        uses: xinova/arangodb-action@v1
-        with:
-          arangodb version: 'latest'
-
-      - name: Setup Arango
-        run: newman run https://raw.githubusercontent.com/frmscoe/postman/indexes/ArangoDB%20Setup.json -e ${{ env.ENV_NEWMAN }} --timeout-request 10200
-
-      - name: Startup Nats
-        uses: onichandame/nats-action@master
-        with:
-          port: 4222
-
-      - name: Startup Redis
-        uses: supercharge/redis-github-action@1.7.0
-        with:
-          redis-version: ${{ matrix.redis-version }}
-
-      - name: Setup Node.js (.npmrc)
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20.x
-          registry-url: https://npm.pkg.github.com/
-          scope: '@frmscoe'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Processor Build
-        run: npm run build
-
-      - name: Processor Start
-        run: npm run start &
-
-      - name: Test Processor
-        run: newman run https://raw.githubusercontent.com/frmscoe/postman/main/micro_processors/TransactionMessageSubmitterProcessor_Proxt_Test.postman_collection.json --iteration-count ${{ env.ITERATION_COUNT }} -e ${{ env.ENV_NEWMAN }} --timeout-request 10200 -r json --reporter-json-export fullReport.json
-
-      - name: Extract Specific Field
-        id: newman_test
-        run: |
-          echo "::set-output name=responseAverage::$(jq -r '.run.timings.responseAverage' fullReport.json)"
-          echo "::set-output name=responseMin::$(jq -r '.run.timings.responseMin' fullReport.json)"
-          echo "::set-output name=responseMax::$(jq -r '.run.timings.responseMax' fullReport.json)"
-          echo "::set-output name=responseSd::$(jq -r '.run.timings.responseSd' fullReport.json)"
-          echo "::set-output name=numberOfTest::$(jq -r '.run.stats.iterations.total' fullReport.json)"
-
-      - name: Get Results For each test
-        id: output_test
-        run: |
-              result="<br />"
-              array_length=$(jq '.collection.item | length' fullReport.json)
-              for ((index=0; index<array_length; index++))
-              do
-                value=$(jq -r ".collection.item[$index].name" fullReport.json)
-                time=$(jq -r ".run.executions[$index].response.responseTime" fullReport.json)
-                result="$result <br /> $((index + 1)). $value took ${time}ms to complete"
-              done
-              result=${result#,}
-              echo "::set-output name=resultOutput::$result"
-
-      - name: Upload Results
-        uses: actions/upload-artifact@v3
-        with:
-          name: Full_Report.json
-          path: fullReport.json
-
-  pastbench:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    outputs:
-      responseMax: ${{ steps.pre_test.outputs.responseMax }}
-      responseAverage: ${{ steps.pre_test.outputs.responseAverage }}
-      responseMin: ${{ steps.pre_test.outputs.responseMin }}
-      numberOfTest: ${{ steps.pre_test.outputs.numberOfTest }}
-      author: ${{ steps.pre_test.outputs.author }}
-      updatedAt: ${{ steps.pre_test.outputs.updatedAt }}
-      prNumber: ${{ steps.pre_test.outputs.prNumber }}
-    steps:
-      - name: Clone repo
-        run: |
-          git clone https://user:$GH_TOKEN@github.com/${{ github.repository_owner }}/${{ env.REPO_NAME }}
-      - name: Extract data
-        id: pre_test
-        run: |
-          cd ${{ env.REPO_NAME }}
-          input=$(tail -n 1 "${{ github.event.repository.name }}".csv)
-          echo "##[set-output name=responseMax]$(echo "$input" | awk -F ';' '{print $1}')"
-          echo "##[set-output name=responseAverage]$(echo "$input" | awk -F ';' '{print $2}')"
-          echo "##[set-output name=responseMin]$(echo "$input" | awk -F ';' '{print $3}')"
-          echo "##[set-output name=numberOfTest]$(echo "$input" | awk -F ';' '{print $4}')"
-          echo "##[set-output name=author]$(echo "$input" | awk -F ';' '{print $5}')"
-          echo "##[set-output name=updatedAt]$(echo "$input" | awk -F ';' '{print $6}')"
-          echo "##[set-output name=prNumber]$(echo "$input" | awk -F ';' '{print $7}')"
-
-  output:
-    if: github.event_name == 'pull_request'
-    needs: [build, pastbench]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Comment on PR
-        run: |
-              difference=$((${{ needs.pastbench.outputs.responseMax }} - ${{ needs.build.outputs.responseMax }}))
-
-              if [ $difference -gt $THRESHOLD ]; then
-                COMMENT="✅ Performance improved"
-              elif [ $difference -ge 0 ]; then
-                COMMENT="✔️ Performance might have improved"
-              elif [ $difference -gt -$THRESHOLD ]; then
-                COMMENT="⚠️ Performance might have declined"
-              else
-                COMMENT="❌ Performance declined"
-              fi
-
-              COMMENT_BODY="🧪 <b>Newman Test Results ${{ needs.build.outputs.resultOutput }} <br /><br /> $COMMENT <br /><br />Current number of tests is ${{ needs.build.outputs.numberOfTest }} and previous was ${{ needs.pastbench.outputs.numberOfTest }} <br /><br />Response stats<blockquote> <li>Current response average is ${{ needs.build.outputs.responseAverage }}ms and previous was ${{ needs.pastbench.outputs.responseAverage }}ms <br /><li>Current response min is ${{ needs.build.outputs.responseMin }}ms and previous was ${{ needs.pastbench.outputs.responseMin }}ms <br /><li>Current response max is ${{ needs.build.outputs.responseMax }}ms and previous was ${{ needs.pastbench.outputs.responseMax }}ms <br /><li>Response standard deviation ${{ needs.build.outputs.responseSd }}ms <br /><br /> Previous PR was merged by ${{ needs.pastbench.outputs.author }} and Pull request number is #${{ needs.pastbench.outputs.prNumber }} at ${{ needs.pastbench.outputs.updatedAt }}"
-
-              API_URL="https://api.github.com/repos/${{github.repository}}/issues/${{github.event.number}}/comments"
-              curl -X POST \
-              -H "Authorization: Bearer ${{ env.GH_TOKEN }}" \
-              -H "Content-Type: application/json" \
-              --data-raw "{\"body\":\"$COMMENT_BODY\",\"assignee\":\"actions-user\"}" \
-              $API_URL
-
-  store:
-    if: github.event_name == 'pull_request'
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Store data
-        run: |
-              # GitHub repository details
-              repo_owner="${{ github.repository_owner }}"
-              repo_name="${{ env.REPO_NAME }}"
-              branch_name="temp-holder"
-              file_path="${{ env.FUNCTION_NAME }}".csv
-
-              # Personal access token with repo scope
-              access_token="${{ env.GH_RW_TOKEN }}"
-
-              new_content="${{ needs.build.outputs.responseMax }};${{ needs.build.outputs.responseAverage }};${{ needs.build.outputs.responseMin }};${{ needs.build.outputs.numberOfTest }};${{ github.actor }};${{ github.event.pull_request.updated_at }};${{ github.event.number}}"
-              updated_content="$new_content"
-              updated_content_base64=$(echo -n "$updated_content" | base64)
-
-              # Get the current content SHA
-              current_content_sha=$(curl -s -H "Authorization: token $access_token" \
-                "https://api.github.com/repos/$repo_owner/$repo_name/contents/$file_path?ref=$branch_name" \
-                | jq -r '.sha')
-
-              request_payload=$(cat <<EOF
-              {
-                "message": "#${{ github.event.number}} Updated file via API",
-                "content": "$updated_content_base64",
-                "sha": "$current_content_sha",
-                "branch": "$branch_name"
-              }
-              EOF
-              )
-
-              curl -L -X PUT \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $access_token" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/$repo_owner/$repo_name/contents/$file_path" \
-              -d "$request_payload"
-
-  test:
-    runs-on: ubuntu-latest
-    name: unit tests
-    strategy:
-      matrix:
-        node-version: [20]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Use Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           registry-url: ${{ env.NPM_REGISTRY }}
           scope: ${{ env.NPM_SCOPE }}
-      - name: Install dependencies
+      - name: Install dependencies 
         run: npm ci
-      - name: Run test
-        run: npm run test
-        env:
-          NODE_ENV: 'test'
+      - name: Run build
+        run: npm run build
 
   lint:
     runs-on: ubuntu-latest
@@ -275,6 +92,26 @@ jobs:
         run: npm ci
       - name: Check linting
         run: npm run lint
+      - name: Check formatting
+        run: npm run lint:prettier
 
-
-
+  test:
+    runs-on: ubuntu-latest
+    name: check tests
+    strategy:
+      matrix:
+        node-version: [20]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          registry-url: ${{ env.NPM_REGISTRY }}
+          scope: ${{ env.NPM_SCOPE }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,46 +5,11 @@
 
 name: Node.js CI
 env:
-  NODE_ENV: 'dev'
-  STARTUP_TYPE: 'nats'
-  SERVER_URL: 'nats://localhost:4222'
-  PRODUCER_STREAM: event-director
-  CONSUMER_STREAM: TMS
-  ACK_POLICY: 'None'
-  STREAM_SUBJECT:
-  APM_ACTIVE: false
-  APM_LOGGING: false
-  FUNCTION_NAME: '${{ github.event.repository.name }}'
-  REDIS_DB: 0
-  REDIS_AUTH:
-  REDIS_SERVERS: '[{"host":"127.0.0.1", "port":6379}]'
-  REDIS_IS_CLUSTER: false
-  DATABASE_NAME: Configuration
-  TRANSACTION_HISTORY_DATABASE_URL: 'http://localhost:8529/'
-  PSEUDONYMS_DATABASE_URL: 'http://localhost:8529/'
-  TRANSACTION_HISTORY_DATABASE_USER: root
-  PSEUDONYMS_DATABASE_USER: root
-  TRANSACTION_HISTORY_DATABASE_PASSWORD:
-  PSEUDONYMS_DATABASE_PASSWORD:
-  PSEUDONYMS_DATABASE: pseudonyms
-  TRANSACTION_HISTORY_DATABASE: transactionHistory
-  TRANSACTION_HISTORY_DATABASE_CERT_PATH: ''
-  PSEUDONYMS_DATABASE_CERT_PATH: ''
-  NODE_TLS_REJECT_UNAUTHORIZED: '0'
-  TRANSACTION_HISTORY_PAIN001_COLLECTION: transactionHistoryPain001
-  TRANSACTION_HISTORY_PAIN013_COLLECTION: transactionHistoryPain013
-  TRANSACTION_HISTORY_PACS008_COLLECTION: transactionHistoryPacs008
-  TRANSACTION_HISTORY_PACS002_COLLECTION: transactionHistoryPacs002
-  QUOTING: true
-  PORT: 3000
-  GH_RW_TOKEN: '${{ secrets.GH_WRITE_TOKEN }}'
-  GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NPM_SCOPE: "@frmscoe"
   NPM_REGISTRY: "https://npm.pkg.github.com/"
-  ENV_NEWMAN: https://raw.githubusercontent.com/frmscoe/postman/indexes/environments/Ekuta-LOCAL.postman_environment.json
-  THRESHOLD: 5
-  REPO_NAME: 'performance-benchmark'
-  ITERATION_COUNT: 500
+  NODE_ENV: 'test'
+  STARTUP_TYPE: 'nats'
 
 on:
   push:


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Unify the node.js.yml workflow across repos by removing integration tests from the run steps.

## Why are we doing this?
The node.js.yaml workflow in this repo was causing failures which blocked the 2.0.0 release.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
