### PR TITLE
feat: updated XchgRate object for Pain001

### DIFF
--- a/src/schemas/pain.001.json
+++ b/src/schemas/pain.001.json
@@ -319,7 +319,7 @@
                           },
                           "required": ["Amt", "Ccy"]
                         },
-                        "XchgRate": {
+                        "XchgRateInf": {
                           "type": "object",
                           "properties": {
                             "UnitCcy": {

--- a/src/schemas/pain.001.json
+++ b/src/schemas/pain.001.json
@@ -314,13 +314,21 @@
                               "type": "string"
                             }
                           },
+                          "CcyOfTrf": {
+                            "type": "string"
+                          },
                           "required": ["Amt", "Ccy"]
                         },
-                        "CcyOfTrf": {
-                          "type": "string"
-                        },
                         "XchgRate": {
-                          "type": "string"
+                          "type": "object",
+                          "properties": {
+                            "UnitCcy": {
+                              "type": "string"
+                            },
+                            "XchgRate": {
+                              "type": "number"
+                            }
+                          }
                         }
                       },
                       "required": ["Amt", "CcyOfTrf"]


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

We updated the exchange rate object in the Pain001 Schema

## Why are we doing this?

To Adhere to ISO200220 Format. 

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
