### PR TITLE
fix: rebuild datacache check on pacs002

### DIFF
--- a/__tests__/unit/app.test.ts
+++ b/__tests__/unit/app.test.ts
@@ -254,6 +254,11 @@ describe('App Controller & Logic Service', () => {
       const request = Pacs002Sample as Pacs002;
 
       const rebuildCacheSpy = jest.spyOn(LogicService, 'rebuildCache');
+
+      jest.spyOn(cacheDatabaseManager, 'getBuffer').mockImplementationOnce(() => {
+        return Promise.resolve({}); // expected behaviour for bad key
+      });
+
       const handleSpy = jest.spyOn(LogicService, 'handlePacs002');
 
       await LogicService.handlePacs002(request, 'pacs.002.001.12');

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -360,7 +360,7 @@ export const handlePacs002 = async (transaction: Pacs002, transactionType: strin
   const spanDataCache = apm.startSpan('req.get.dataCache.pacs002');
   try {
     const dataCacheJSON = (await cacheDatabaseManager.getBuffer(EndToEndId)).DataCache;
-    dataCache = dataCacheJSON as DataCache;
+    dataCache = dataCacheJSON ? (dataCacheJSON as DataCache) : await rebuildCache(EndToEndId, false, id);
   } catch (ex) {
     loggerService.error(`Could not retrieve data cache for: ${EndToEndId} from redis`, logContext, id);
     loggerService.log('Proceeding with Arango Call', logContext, id);


### PR DESCRIPTION
## What did we change?
Add a check to prevent empty datacache and trigger a rebuild

## Why are we doing this?
Issue https://github.com/tazama-lf/tms-service/issues/286

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
