### PR TITLE
build: fix failing scorecard workflow run

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -59,7 +59,7 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
-      # Upload the SARIF file generated in the previous step
+      # Upload the SARIF file generated in the previous step.
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -63,7 +63,7 @@ jobs:
       - name: "Upload artifact"
         uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
         with:
-          name: SARIF file
+          name: sarif_results
           path: results.sarif
           retention-days: 5
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Update the artifact name to use a valid, space-free string

## Why are we doing this?
The run has been failing every now and then because of a wrong workflow syntax with an error`"The artifact name SARIF file is not valid."`

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
