### PR TITLE
fix: use BuildKit secret for GH_TOKEN (tazama-lf/workflows#52)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG BUILD_IMAGE=node:20-bullseye
 ARG RUN_IMAGE=gcr.io/distroless/nodejs20-debian11:nonroot
 
@@ -11,9 +12,8 @@ COPY ./package*.json ./
 COPY ./tsconfig.json ./
 COPY ./swagger.yaml ./
 COPY .npmrc ./
-ARG GH_TOKEN
 
-RUN npm ci --ignore-scripts
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --ignore-scripts
 RUN npm run build
 
 FROM ${BUILD_IMAGE} AS dep-resolver
@@ -22,8 +22,7 @@ LABEL stage=pre-prod
 
 COPY package*.json ./
 COPY .npmrc ./
-ARG GH_TOKEN
-RUN npm ci --omit=dev --ignore-scripts
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --omit=dev --ignore-scripts
 
 FROM ${RUN_IMAGE} AS run-env
 USER nonroot


### PR DESCRIPTION
Removes `ARG GH_TOKEN` from all build stages and replaces plain `npm ci` with
`RUN --mount=type=secret` so the GitHub PAT used for `npm install` is never
stored in image layer history (`docker history`).

Requires `# syntax=docker/dockerfile:1` directive at the top of the Dockerfile
to enable BuildKit extended RUN syntax.

Part of the coordinated migration tracked in tazama-lf/workflows#52.

**NOTE: Do not merge the canonical workflow PR (tazama-lf/workflows) until all
service repo Dockerfiles have been updated. See tazama-lf/workflows#52 for
rollout order.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build configuration to improve build process efficiency and security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->